### PR TITLE
Improve scanner reliability and CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,32 +3,49 @@ name: github-pages
 on: push
 
 jobs:
-  pages:
+  core-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20.x'
-
-      - name: Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}
+      - uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 8.15.9
 
-      - name: pnpm install
-        run: pnpm install --no-frozen-lockfile
-      - name: build pages
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test core package
+        run: pnpm --filter componentlook test
+
+  pages:
+    runs-on: ubuntu-latest
+    needs: core-tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build pages
         run: pnpm --filter @componentlook/web run build
 
       - name: GitHub Pages action

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@8.15.9",
   "pnpm": {
     "overrides": {
       "rollup": "npm:@rollup/wasm-node"

--- a/packages/core/bin.js
+++ b/packages/core/bin.js
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import sade from "sade";
 import { parse } from "./src/index.js";
 
+const packageJson = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8")
+);
 const prog = sade("componentlook", true);
 
 prog
-  .version("1.0.0")
+  .version(packageJson.version)
   .describe("find component types in your project")
   .example("my-entry")
   .option('--tsconfig', 'Specify a tsconfig file')

--- a/packages/core/bin.js
+++ b/packages/core/bin.js
@@ -12,6 +12,9 @@ prog
   .option('--tsconfig', 'Specify a tsconfig file')
   .action((opts) => {
     const {_, ...rest} = opts
-    parse(_, rest);
+    parse(_, rest).catch((error) => {
+      console.error(error.message || error);
+      process.exitCode = 1;
+    });
   })
   .parse(process.argv);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "componentlook",
   "version": "1.0.2",
-  "description": "",
+  "description": "Static analysis toolkit for detecting React and Vue component writing styles.",
   "exports": {
     "./package.json": "./package.json",
     ".": "./src/index.js",
@@ -12,8 +12,15 @@
     "test": "uvu tests -i fixtures",
     "start": "node tests/parse-react-file/index.test.js"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "react",
+    "vue",
+    "component",
+    "static-analysis",
+    "ast",
+    "cli"
+  ],
+  "author": "brandonxiang",
   "license": "MIT",
   "dependencies": {
     "typescript": "5.4.3",

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -13,6 +13,17 @@ import { existsSync } from "fs";
 import { createHost } from "./typescript/create-host.js";
 import { componentScanner } from './slim.js';
  
+export class ScannerError extends Error {
+  /**
+   * @param {string} message
+   * @param {string} code
+   */
+  constructor(message, code) {
+    super(message);
+    this.name = 'ScannerError';
+    this.code = code;
+  }
+}
 
 
 /**
@@ -25,22 +36,26 @@ export async function projectScanner(_entry, options) {
   const entry = _entry.map((m) => path.resolve(m));
   entry.forEach((e) => {
     if (!existsSync(e)) {
-      console.error('Entry file not found. ');
-      process.exit(-1);
+      throw new ScannerError(`Entry file not found: ${e}`, 'ENTRY_NOT_FOUND');
     }
   });
 
-  const defaultTsconfigPath = path.resolve("tsconfig.json");
-  const defaultPackageJsonPath = path.resolve("package.json");
-  if (!existsSync(defaultPackageJsonPath)) {
-    console.error('Please run at the workspace root. ');
-    process.exit(-1);
+  const tsconfigPath = path.resolve(options?.tsconfig || "tsconfig.json");
+  const packageJsonPath = path.resolve(options?.packageJson || "package.json");
+
+  if (!existsSync(packageJsonPath)) {
+    throw new ScannerError(
+      `Package manifest not found: ${packageJsonPath}. Run from the workspace root or pass packageJson.`,
+      'PACKAGE_JSON_NOT_FOUND'
+    );
   }
-  if (!existsSync(defaultTsconfigPath)) {
-    console.error('Please add a tsconfig at the workspace root, or customize it. ');
-    process.exit(-1);
+  if (!existsSync(tsconfigPath)) {
+    throw new ScannerError(
+      `TypeScript config not found: ${tsconfigPath}. Add tsconfig.json or pass tsconfig.`,
+      'TSCONFIG_NOT_FOUND'
+    );
   }
-  const tsConfig = await readJson(options?.tsconfig || defaultTsconfigPath);
+  const tsConfig = await readJson(tsconfigPath);
 
   const compilerOptions = {
     ...tsConfig.compilerOptions,
@@ -49,7 +64,7 @@ export async function projectScanner(_entry, options) {
   }
 
   delete compilerOptions.moduleResolution;
-  const packageJson = await readJson(options?.packageJson || defaultPackageJsonPath);
+  const packageJson = await readJson(packageJsonPath);
   
   const dependencies = getDependencies(packageJson);
   const isReact = dependencies.has('react');

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -58,44 +58,51 @@ export async function projectScanner(_entry, options) {
 
   /**
    * A Map to store cached values.
-   * @type {Map<string, string>}
+   * @type {Map<string, Set<string>>}
    */
   let cache = new Map();
   /** @type {ts.SourceFile | null} */
   let currentSourceFile = null;
+  /** @param {string} componentType */
+  const addComponentType = (componentType) => {
+    if (!currentSourceFile?.fileName) return;
+
+    const currentTypes = cache.get(currentSourceFile.fileName) || new Set();
+    currentTypes.add(componentType);
+    cache.set(currentSourceFile.fileName, currentTypes);
+  };
+
   /** @param {ts.Node} node */
   const visit = (node) => {
     if (isReact && currentSourceFile?.fileName) {
       if (isReactFunctionComponent(node)) {
-        cache.set(currentSourceFile.fileName, COMPONENT_TYPE.REACT_FUNCTION);
+        addComponentType(COMPONENT_TYPE.REACT_FUNCTION);
       }
 
       if (isReactClassComponent(node)) {
-        cache.set(currentSourceFile.fileName, COMPONENT_TYPE.REACT_CLASS);
+        addComponentType(COMPONENT_TYPE.REACT_CLASS);
       }
     }
 
     if (isVue && currentSourceFile?.fileName) {
       if (isVueJSX(node)) {
-        cache.set(currentSourceFile.fileName, COMPONENT_TYPE.VUE_JSX);
+        addComponentType(COMPONENT_TYPE.VUE_JSX);
       }
 
       if (isVueOptionAPI(node)) {
-        cache.set(currentSourceFile.fileName, COMPONENT_TYPE.VUE_OPTION);
+        addComponentType(COMPONENT_TYPE.VUE_OPTION);
       }
 
       if (isVueClassAPI(node)) {
-        cache.set(currentSourceFile.fileName, COMPONENT_TYPE.VUE_CLASS);
+        addComponentType(COMPONENT_TYPE.VUE_CLASS);
       }
 
       if (isVueCompositionAPI(node)) {
-        cache.set(currentSourceFile.fileName, COMPONENT_TYPE.VUE_COMPOSITION);
+        addComponentType(COMPONENT_TYPE.VUE_COMPOSITION);
       }
     }
 
-    if (currentSourceFile?.fileName && !cache.get(currentSourceFile.fileName)) {
-      ts.forEachChild(node, visit);
-    }
+    ts.forEachChild(node, visit);
   };
 
   const compilerHost = createHost({ compilerOptions });

--- a/packages/core/src/pattern/react/functionComponent.js
+++ b/packages/core/src/pattern/react/functionComponent.js
@@ -1,9 +1,60 @@
-  import ts from 'typescript';
-  
-  /**
-   * 检查节点是否为函数式 JSX 元素
-   * @param {ts.Node} node 
-   */
-  export function isReactFunctionComponent(node) {
-    return node.kind === ts.SyntaxKind.JsxElement || node.kind === ts.SyntaxKind.JsxSelfClosingElement;
+import ts from 'typescript';
+
+/**
+ * @param {ts.Node | undefined} node
+ */
+function containsJSX(node) {
+  if (!node) return false;
+  let hasJSX = false;
+
+  const visit = (child) => {
+    if (
+      ts.isJsxElement(child) ||
+      ts.isJsxSelfClosingElement(child) ||
+      ts.isJsxFragment(child)
+    ) {
+      hasJSX = true;
+      return;
+    }
+
+    if (!hasJSX) {
+      ts.forEachChild(child, visit);
+    }
+  };
+
+  visit(node);
+  return hasJSX;
+}
+
+/**
+ * @param {ts.ConciseBody} body
+ */
+function returnsJSX(body) {
+  if (!ts.isBlock(body)) {
+    return containsJSX(body);
   }
+
+  return body.statements.some((statement) => (
+    ts.isReturnStatement(statement) && containsJSX(statement.expression)
+  ));
+}
+
+/**
+ * Check whether a node is a function-style component declaration.
+ *
+ * @param {ts.Node} node
+ */
+export function isReactFunctionComponent(node) {
+  if (ts.isFunctionDeclaration(node) && node.body) {
+    return returnsJSX(node.body);
+  }
+
+  if (
+    (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
+    returnsJSX(node.body)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/core/src/pattern/vue/composition.js
+++ b/packages/core/src/pattern/vue/composition.js
@@ -1,26 +1,118 @@
 import ts from 'typescript';
 
 /**
- * Check if the node is a Vue Composition component.
+ * @param {ts.PropertyName} name
+ */
+function getPropertyName(name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+
+  return name.getText();
+}
+
+/**
+ * @param {ts.ObjectLiteralExpression} node
+ */
+function hasSetupProperty(node) {
+  return node.properties.some((property) => {
+    if (ts.isPropertyAssignment(property) || ts.isMethodDeclaration(property)) {
+      return getPropertyName(property.name) === 'setup';
+    }
+
+    return false;
+  });
+}
+
+/**
+ * @param {ts.ObjectLiteralExpression} node
+ */
+function isExportDefaultObject(node) {
+  const parent = node.parent;
+
+  return (
+    ts.isExportAssignment(parent) ||
+    (
+      ts.isParenthesizedExpression(parent) &&
+      ts.isExportAssignment(parent.parent)
+    )
+  );
+}
+
+/**
+ * @param {ts.ObjectLiteralExpression} node
+ */
+function isVueComponentCallArgument(node) {
+  const parent = node.parent;
+  if (!ts.isCallExpression(parent) || parent.arguments[0] !== node) return false;
+
+  const expression = parent.expression;
+  if (ts.isIdentifier(expression)) {
+    return expression.text === 'defineComponent';
+  }
+
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    expression.name.text === 'extend' &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === 'Vue'
+  );
+}
+
+/**
+ * @param {ts.SourceFile} sourceFile
+ */
+function getVueNamedImports(sourceFile) {
+  const vueImports = new Set();
+
+  sourceFile.statements.forEach((statement) => {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== 'vue'
+    ) {
+      return;
+    }
+
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) return;
+
+    namedBindings.elements.forEach((element) => {
+      vueImports.add(element.name.text);
+    });
+  });
+
+  return vueImports;
+}
+
+/**
+ * @param {ts.CallExpression} node
+ */
+function isVueCompositionCall(node) {
+  const expression = node.expression;
+  const compositionNames = new Set(['ref', 'reactive', 'computed', 'watch']);
+
+  if (!ts.isIdentifier(expression) || !compositionNames.has(expression.text)) {
+    return false;
+  }
+
+  return getVueNamedImports(node.getSourceFile()).has(expression.text);
+}
+
+/**
+ * Check if the node is a Vue Composition API component.
  *
  * @param {ts.Node} node - the node to be checked
- * @return {boolean} true if the node is a Vue option component, false otherwise
- */export const isVueCompositionAPI = (node) => {
-    // 检查是否为调用表达式
-    if (ts.isCallExpression(node)) {
-      // 获取调用表达式的名称
-      const expression = node.expression;
-      let name = "";
-      if (ts.isIdentifier(expression)) {
-        name = expression.text;
-      } else if (ts.isPropertyAccessExpression(expression)) {
-        name = expression.name.text;
-      }
+ * @return {boolean} true if the node is a Vue Composition API component, false otherwise
+ */
+export const isVueCompositionAPI = (node) => {
+  if (ts.isObjectLiteralExpression(node) && hasSetupProperty(node)) {
+    return isExportDefaultObject(node) || isVueComponentCallArgument(node);
+  }
 
-      // 检查是否调用了 Composition API 特征函数
-      if (name === 'setup' || name === 'ref' || name === 'reactive' || name === 'computed' || name === 'watch') {
-        return true;
-      }
-    }
-    return false;
+  if (ts.isCallExpression(node)) {
+    return isVueCompositionCall(node);
+  }
+
+  return false;
 }

--- a/packages/core/src/pattern/vue/jsx.js
+++ b/packages/core/src/pattern/vue/jsx.js
@@ -34,22 +34,5 @@ export const isVueJSX = (node) => {
     }
   }
   // 检查函数表达式，可能是无状态组件
-  else if (ts.isVariableStatement(node)) {
-    for (const declaration of node.declarationList.declarations) {
-      if (declaration.initializer && (ts.isArrowFunction(declaration.initializer) || ts.isFunctionExpression(declaration.initializer))) {
-        const functionBody = declaration.initializer.body;
-        if (ts.isBlock(functionBody)) {
-          functionBody.statements.forEach((statement) => {
-            if (ts.isReturnStatement(statement) && statement.expression) {
-              checkForJSXElement(statement.expression);
-            }
-          });
-        } else if (functionBody) {
-          // 当函数体是一个单一表达式时，它可能直接返回 JSX
-          checkForJSXElement(functionBody);
-        }
-      }
-    }
-  }
   return usesJSX;
 };

--- a/packages/core/src/pattern/vue/option.js
+++ b/packages/core/src/pattern/vue/option.js
@@ -1,26 +1,80 @@
 import ts from 'typescript';
 
 /**
- * Check if the node is a Vue Composition component.
+ * @param {ts.PropertyName} name
+ */
+function getPropertyName(name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+
+  return name.getText();
+}
+
+/**
+ * @param {ts.ObjectLiteralExpression} node
+ */
+function hasOptionsAPIProperty(node) {
+  const optionNames = new Set(['data', 'methods', 'computed', 'watch']);
+
+  return node.properties.some((property) => {
+    if (
+      ts.isPropertyAssignment(property) ||
+      ts.isMethodDeclaration(property) ||
+      ts.isGetAccessorDeclaration(property)
+    ) {
+      return optionNames.has(getPropertyName(property.name));
+    }
+
+    return false;
+  });
+}
+
+/**
+ * @param {ts.ObjectLiteralExpression} node
+ */
+function isExportDefaultObject(node) {
+  const parent = node.parent;
+
+  return (
+    ts.isExportAssignment(parent) ||
+    (
+      ts.isParenthesizedExpression(parent) &&
+      ts.isExportAssignment(parent.parent)
+    )
+  );
+}
+
+/**
+ * @param {ts.ObjectLiteralExpression} node
+ */
+function isVueComponentCallArgument(node) {
+  const parent = node.parent;
+  if (!ts.isCallExpression(parent) || parent.arguments[0] !== node) return false;
+
+  const expression = parent.expression;
+  if (ts.isIdentifier(expression)) {
+    return expression.text === 'defineComponent';
+  }
+
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    expression.name.text === 'extend' &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === 'Vue'
+  );
+}
+
+/**
+ * Check if the node is a Vue Options API component.
  *
  * @param {ts.Node} node - the node to be checked
- * @return {boolean} true if the node is a Vue option component, false otherwise
+ * @return {boolean} true if the node is a Vue options component, false otherwise
  */
 export const isVueOptionAPI = (node) => {
-
-    // 检查是否为对象字面量表达式
-    if (ts.isObjectLiteralExpression(node)) {
-      // 检查对象字面量的属性
-      for (let index = 0; index < node.properties.length; index++) {
-        const property = node.properties[index];
-        if (ts.isPropertyAssignment(property)) {
-          const name = property.name.getText();
-          // 检查是否是 Options API 的特征属性
-          if (name === 'data' || name === 'methods' || name === 'computed' || name === 'watch') {
-            return true;
-          }
-        }
-      }
-    }
+  if (!ts.isObjectLiteralExpression(node) || !hasOptionsAPIProperty(node)) {
     return false;
+  }
+
+  return isExportDefaultObject(node) || isVueComponentCallArgument(node);
 }

--- a/packages/core/src/slim.js
+++ b/packages/core/src/slim.js
@@ -22,36 +22,31 @@ export function componentScanner(sourceFile) {
    */
   const visit = (node) => {
     if (isReactFunctionComponent(node)) {
-      console.log("is React Function Component");
       containsJsxElement = true;
       componentType = COMPONENT_TYPE.REACT_FUNCTION;
     }
 
     if (isReactClassComponent(node)) {
-      console.log("is React Class Component");
       containsJsxElement = true;
       componentType = COMPONENT_TYPE.REACT_CLASS;
     }
 
-    // if(isVueJSX(node)) {
-    //   console.log('is Vue JSX API');
-    //   containsJsxElement = true;
-    // }
+    if (isVueJSX(node)) {
+      containsJsxElement = true;
+      componentType = COMPONENT_TYPE.VUE_JSX;
+    }
 
     if (isVueClassAPI(node)) {
-      console.log("is Vue Class API");
       containsJsxElement = true;
       componentType = COMPONENT_TYPE.VUE_CLASS;
     }
 
     if (isVueCompositionAPI(node)) {
-      console.log("is Vue Composition API");
       containsJsxElement = true;
       componentType = COMPONENT_TYPE.VUE_COMPOSITION;
     }
 
     if (isVueOptionAPI(node)) {
-      console.log("is Vue Option API");
       containsJsxElement = true;
       componentType = COMPONENT_TYPE.VUE_OPTION;
     }

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 /**
  *
- * @param {Map<string, string>} cache
+ * @param {Map<string, string | Set<string>>} cache
  */
 export function convertResult(cache) {
   const reactFunctionFileList = [];
@@ -14,22 +14,24 @@ export function convertResult(cache) {
   const vueJsxFileList = [];
 
   for (const [key, value] of cache) {
-    if (value === COMPONENT_TYPE.REACT_FUNCTION) {
+    const componentTypes = value instanceof Set ? value : new Set([value]);
+
+    if (componentTypes.has(COMPONENT_TYPE.REACT_FUNCTION)) {
       reactFunctionFileList.push(key);
     }
-    if (value === COMPONENT_TYPE.REACT_CLASS) {
+    if (componentTypes.has(COMPONENT_TYPE.REACT_CLASS)) {
       reactClassFileList.push(key);
     }
-    if (value === COMPONENT_TYPE.VUE_OPTION) {
+    if (componentTypes.has(COMPONENT_TYPE.VUE_OPTION)) {
       vueOptionFileList.push(key);
     }
-    if (value === COMPONENT_TYPE.VUE_COMPOSITION) {
+    if (componentTypes.has(COMPONENT_TYPE.VUE_COMPOSITION)) {
       vueCompositionFileList.push(key);
     }
-    if (value === COMPONENT_TYPE.VUE_CLASS) {
+    if (componentTypes.has(COMPONENT_TYPE.VUE_CLASS)) {
       vueClassFileList.push(key);
     }
-    if (value === COMPONENT_TYPE.VUE_JSX) {
+    if (componentTypes.has(COMPONENT_TYPE.VUE_JSX)) {
       vueJsxFileList.push(key);
     }
   }

--- a/packages/core/tests/cli/index.test.js
+++ b/packages/core/tests/cli/index.test.js
@@ -1,0 +1,21 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'path';
+
+const packageJson = JSON.parse(
+  readFileSync(path.resolve('package.json'), 'utf8')
+);
+
+test('prints the package version', () => {
+  const output = execFileSync(
+    process.execPath,
+    [path.resolve('bin.js'), '--version'],
+    { encoding: 'utf8' }
+  ).trim();
+
+  assert.equal(output, `componentlook, ${packageJson.version}`);
+});
+
+test.run();

--- a/packages/core/tests/parse-react-file/index.test.js
+++ b/packages/core/tests/parse-react-file/index.test.js
@@ -1,6 +1,7 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { convertResult, projectScanner } from '../../src/index.js';
+import { COMPONENT_TYPE } from '../../src/constant/index.js';
 import path from 'path';
 
 const entry = path.resolve('fixtures/react/src/index.tsx');
@@ -12,11 +13,22 @@ test('parse react project', async () => {
   const res1 = convertResult(temp);
   assert.equal(res1.reactFunctionFileList, [
     path.resolve('fixtures/react/src/head.tsx'),
-    path.resolve('fixtures/react/src/foot.tsx')
+    path.resolve('fixtures/react/src/foot.tsx'),
+    path.resolve('fixtures/react/src/index.tsx')
   ]);
   assert.equal(res1.reactClassFileList, [
     path.resolve('fixtures/react/src/index.tsx')
   ]);
+});
+
+test('convert result preserves multiple component styles per file', () => {
+  const fileName = path.resolve('fixtures/react/src/mixed.tsx');
+  const res1 = convertResult(new Map([
+    [fileName, new Set([COMPONENT_TYPE.REACT_FUNCTION, COMPONENT_TYPE.REACT_CLASS])]
+  ]));
+
+  assert.equal(res1.reactFunctionFileList, [fileName]);
+  assert.equal(res1.reactClassFileList, [fileName]);
 });
 
 test.run();

--- a/packages/core/tests/parse-react-file/index.test.js
+++ b/packages/core/tests/parse-react-file/index.test.js
@@ -1,6 +1,3 @@
-
-
-
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { convertResult, projectScanner } from '../../src/index.js';
@@ -10,20 +7,16 @@ const entry = path.resolve('fixtures/react/src/index.tsx');
 const tsconfig = path.resolve('fixtures/react/tsconfig.json');
 const packageJson = path.resolve('fixtures/react/package.json');
 
-console.log(entry, tsconfig, packageJson );
-
 test('parse react project', async () => {
   const temp = await projectScanner([entry], { tsconfig, packageJson });
-  console.log(temp)
   const res1 = convertResult(temp);
   assert.equal(res1.reactFunctionFileList, [
-    '/Users/weipingxiang/github/componentlook/packages/core/fixtures/react/src/head.tsx',
-    '/Users/weipingxiang/github/componentlook/packages/core/fixtures/react/src/foot.tsx'
+    path.resolve('fixtures/react/src/head.tsx'),
+    path.resolve('fixtures/react/src/foot.tsx')
   ]);
   assert.equal(res1.reactClassFileList, [
-    '/Users/weipingxiang/github/componentlook/packages/core/fixtures/react/src/index.tsx'
+    path.resolve('fixtures/react/src/index.tsx')
   ]);
 });
 
 test.run();
-

--- a/packages/core/tests/parse-react-file/index.test.js
+++ b/packages/core/tests/parse-react-file/index.test.js
@@ -13,8 +13,7 @@ test('parse react project', async () => {
   const res1 = convertResult(temp);
   assert.equal(res1.reactFunctionFileList, [
     path.resolve('fixtures/react/src/head.tsx'),
-    path.resolve('fixtures/react/src/foot.tsx'),
-    path.resolve('fixtures/react/src/index.tsx')
+    path.resolve('fixtures/react/src/foot.tsx')
   ]);
   assert.equal(res1.reactClassFileList, [
     path.resolve('fixtures/react/src/index.tsx')

--- a/packages/core/tests/parse-vue-file/index.test.js
+++ b/packages/core/tests/parse-vue-file/index.test.js
@@ -1,6 +1,6 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { convertResult, parse, projectScanner } from '../../src/index.js';
+import { convertResult, projectScanner } from '../../src/index.js';
 import path from 'path';
 
 const entry = path.resolve('fixtures/vue/src/main.ts');
@@ -9,20 +9,20 @@ const tsconfig = path.resolve('fixtures/vue/tsconfig.json');
 const packageJson = path.resolve('fixtures/vue/package.json');
 
 
-test('parse react project', async () => {
+test('parse vue project', async () => {
   const temp = await projectScanner([entry], { tsconfig, packageJson });
   const res1 = convertResult(temp);
   assert.equal(res1.vueOptionFileList, [
-    '/Users/weipingxiang/github/componentlook/packages/core/fixtures/vue/src/Book.vue'
+    path.resolve('fixtures/vue/src/Book.vue')
   ]);
   assert.equal(res1.vueCompositionFileList, [
-    '/Users/weipingxiang/github/componentlook/packages/core/fixtures/vue/src/Head.vue'
+    path.resolve('fixtures/vue/src/Head.vue')
   ]);
   assert.equal(res1.vueClassFileList, [
-    '/Users/weipingxiang/github/componentlook/packages/core/fixtures/vue/src/Foot.vue'
+    path.resolve('fixtures/vue/src/Foot.vue')
   ]);
   assert.equal(res1.vueJsxFileList, [
-    '/Users/weipingxiang/github/componentlook/packages/core/fixtures/vue/src/Button.tsx'
+    path.resolve('fixtures/vue/src/Button.tsx')
   ]);
 });
 

--- a/packages/core/tests/project-scanner-errors/index.test.js
+++ b/packages/core/tests/project-scanner-errors/index.test.js
@@ -1,0 +1,40 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { projectScanner } from '../../src/index.js';
+import path from 'path';
+
+const entry = path.resolve('fixtures/react/src/index.tsx');
+const tsconfig = path.resolve('fixtures/react/tsconfig.json');
+const packageJson = path.resolve('fixtures/react/package.json');
+
+async function expectScannerError(promise, code) {
+  try {
+    await promise;
+    assert.unreachable('Expected projectScanner to reject');
+  } catch (error) {
+    assert.equal(error.code, code);
+  }
+}
+
+test('throws for missing entry files', async () => {
+  await expectScannerError(
+    projectScanner([path.resolve('fixtures/react/src/missing.tsx')], { tsconfig, packageJson }),
+    'ENTRY_NOT_FOUND'
+  );
+});
+
+test('throws for missing package.json', async () => {
+  await expectScannerError(
+    projectScanner([entry], { tsconfig, packageJson: path.resolve('fixtures/react/missing-package.json') }),
+    'PACKAGE_JSON_NOT_FOUND'
+  );
+});
+
+test('throws for missing tsconfig.json', async () => {
+  await expectScannerError(
+    projectScanner([entry], { tsconfig: path.resolve('fixtures/react/missing-tsconfig.json'), packageJson }),
+    'TSCONFIG_NOT_FOUND'
+  );
+});
+
+test.run();

--- a/packages/core/tests/react/class.test.js
+++ b/packages/core/tests/react/class.test.js
@@ -1,10 +1,8 @@
-
-
-
 import ts from 'typescript';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { componentScanner } from '../../src/index.js';
+import { COMPONENT_TYPE } from '../../src/constant/index.js';
 
 const reactClassCode = `
 import React, { Component } from 'react';
@@ -32,12 +30,12 @@ class AnotherClass {
 
 test('judge react class component', () => {
   const sourceFile = ts.createSourceFile('MyComponent.tsx', reactClassCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), true);
+  assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.REACT_CLASS);
 });
 
 test('judge normal class', () => {
   const sourceFile = ts.createSourceFile('MyComponent.tsx', normalCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), false);
+  assert.equal(componentScanner(sourceFile), '');
 });
 
 test.run();

--- a/packages/core/tests/react/function.test.js
+++ b/packages/core/tests/react/function.test.js
@@ -18,7 +18,14 @@ const normalCode = `
 function nonComponent() {
   return Math.random();
 }
-`; 
+`;
+
+const nestedJSXCode = `
+function nonComponent() {
+  const view = <div>Hello</div>;
+  return view;
+}
+`;
 
 test('judge react function component', () => {
   const sourceFile = ts.createSourceFile('MyComponent.tsx', reactFunctionCode, ts.ScriptTarget.Latest, true);
@@ -27,6 +34,11 @@ test('judge react function component', () => {
 
 test('judge normal function', () => {
   const sourceFile = ts.createSourceFile('MyComponent.tsx', normalCode, ts.ScriptTarget.Latest, true);
+  assert.equal(componentScanner(sourceFile), '');
+});
+
+test('does not classify arbitrary nested JSX as a function component', () => {
+  const sourceFile = ts.createSourceFile('MyComponent.tsx', nestedJSXCode, ts.ScriptTarget.Latest, true);
   assert.equal(componentScanner(sourceFile), '');
 });
 

--- a/packages/core/tests/react/function.test.js
+++ b/packages/core/tests/react/function.test.js
@@ -4,6 +4,7 @@ import ts from 'typescript';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { componentScanner } from '../../src/index.js';
+import { COMPONENT_TYPE } from '../../src/constant/index.js';
 
 const reactFunctionCode = `
 import React from 'react';
@@ -21,12 +22,12 @@ function nonComponent() {
 
 test('judge react function component', () => {
   const sourceFile = ts.createSourceFile('MyComponent.tsx', reactFunctionCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), true);
+  assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.REACT_FUNCTION);
 });
 
 test('judge normal function', () => {
   const sourceFile = ts.createSourceFile('MyComponent.tsx', normalCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), false);
+  assert.equal(componentScanner(sourceFile), '');
 });
 
 test.run();

--- a/packages/core/tests/vue/class.test.js
+++ b/packages/core/tests/vue/class.test.js
@@ -1,10 +1,8 @@
-
-
-
 import ts from 'typescript';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { componentScanner } from '../../src/index.js';
+import { COMPONENT_TYPE } from '../../src/constant/index.js';
 
 const targetCode = `
 import { Component, Vue } from 'vue-property-decorator';
@@ -29,12 +27,12 @@ class AnotherClass {
 
 test('judge vue class component', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', targetCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), true);
+  assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.VUE_CLASS);
 });
 
 test('judge normal code', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', normalCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), false);
+  assert.equal(componentScanner(sourceFile), '');
 });
 
 test.run();

--- a/packages/core/tests/vue/composition.test.js
+++ b/packages/core/tests/vue/composition.test.js
@@ -29,6 +29,12 @@ class AnotherClass {
 }
 `
 
+const nonVueImportCode = `
+import { reactive } from 'state-lib';
+
+const state = reactive({ count: 0 });
+`
+
 test('judge vue composition API', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', targetCode, ts.ScriptTarget.Latest, true);
   assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.VUE_COMPOSITION);
@@ -36,6 +42,11 @@ test('judge vue composition API', () => {
 
 test('judge normal code', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', normalCode, ts.ScriptTarget.Latest, true);
+  assert.equal(componentScanner(sourceFile), '');
+});
+
+test('does not classify composition-like calls from non-vue imports', () => {
+  const sourceFile = ts.createSourceFile('MyComponent.vue', nonVueImportCode, ts.ScriptTarget.Latest, true);
   assert.equal(componentScanner(sourceFile), '');
 });
 

--- a/packages/core/tests/vue/composition.test.js
+++ b/packages/core/tests/vue/composition.test.js
@@ -2,6 +2,7 @@ import ts from 'typescript';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { componentScanner } from '../../src/index.js';
+import { COMPONENT_TYPE } from '../../src/constant/index.js';
 
 const targetCode = `
 import { ref, reactive } from 'vue';
@@ -30,12 +31,12 @@ class AnotherClass {
 
 test('judge vue composition API', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', targetCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), true);
+  assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.VUE_COMPOSITION);
 });
 
 test('judge normal code', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', normalCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), false);
+  assert.equal(componentScanner(sourceFile), '');
 });
 
 test.run();

--- a/packages/core/tests/vue/jsx.test.js
+++ b/packages/core/tests/vue/jsx.test.js
@@ -25,7 +25,7 @@ class AnotherClass {
 
 test('judge vue jsx api', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', targetCode, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-  assert.equal(componentScanner(sourceFile), '');
+  assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.VUE_JSX);
 });
 
 test('judge normal code', () => {

--- a/packages/core/tests/vue/jsx.test.js
+++ b/packages/core/tests/vue/jsx.test.js
@@ -25,7 +25,7 @@ class AnotherClass {
 
 test('judge vue jsx api', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', targetCode, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-  assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.REACT_FUNCTION);
+  assert.equal(componentScanner(sourceFile), '');
 });
 
 test('judge normal code', () => {

--- a/packages/core/tests/vue/jsx.test.js
+++ b/packages/core/tests/vue/jsx.test.js
@@ -1,10 +1,8 @@
-
-
-
 import ts from 'typescript';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { componentScanner } from '../../src/index.js';
+import { COMPONENT_TYPE } from '../../src/constant/index.js';
 
 const targetCode = `
 import Vue, { VNode } from 'vue';
@@ -27,12 +25,12 @@ class AnotherClass {
 
 test('judge vue jsx api', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', targetCode, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-  assert.equal(componentScanner(sourceFile), true);
+  assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.REACT_FUNCTION);
 });
 
 test('judge normal code', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', normalCode, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-  assert.equal(componentScanner(sourceFile), false);
+  assert.equal(componentScanner(sourceFile), '');
 });
 
 test.run();

--- a/packages/core/tests/vue/option.test.js
+++ b/packages/core/tests/vue/option.test.js
@@ -1,10 +1,8 @@
-
-
-
 import ts from 'typescript';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { componentScanner } from '../../src/index.js';
+import { COMPONENT_TYPE } from '../../src/constant/index.js';
 
 const targetCode = `
 export default {
@@ -31,12 +29,12 @@ export default {
 
 test('judge vue option api', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', targetCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), true);
+  assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.VUE_OPTION);
 });
 
 test('judge normal object', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', normalCode, ts.ScriptTarget.Latest, true);
-  assert.equal(componentScanner(sourceFile), false);
+  assert.equal(componentScanner(sourceFile), '');
 });
 
 test.run();

--- a/packages/core/tests/vue/option.test.js
+++ b/packages/core/tests/vue/option.test.js
@@ -27,6 +27,13 @@ export default {
 }
 `
 
+const nonComponentObjectCode = `
+const tableConfig = {
+  data: [],
+  methods: {}
+}
+`;
+
 test('judge vue option api', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', targetCode, ts.ScriptTarget.Latest, true);
   assert.equal(componentScanner(sourceFile), COMPONENT_TYPE.VUE_OPTION);
@@ -34,6 +41,11 @@ test('judge vue option api', () => {
 
 test('judge normal object', () => {
   const sourceFile = ts.createSourceFile('MyComponent.vue', normalCode, ts.ScriptTarget.Latest, true);
+  assert.equal(componentScanner(sourceFile), '');
+});
+
+test('does not classify arbitrary objects with option-like keys', () => {
+  const sourceFile = ts.createSourceFile('MyComponent.vue', nonComponentObjectCode, ts.ScriptTarget.Latest, true);
   assert.equal(componentScanner(sourceFile), '');
 });
 


### PR DESCRIPTION
## Summary

This PR implements the optimization plan from #2 with one focused commit per improvement area.

## Commits

1. `test: make scanner tests portable`
   - Removes user-specific absolute paths from tests.
   - Updates stale boolean assertions to match the current scanner API.

2. `feat: preserve multiple component styles`
   - Stores multiple component types per file with a `Set`.
   - Keeps `convertResult` compatible with previous string-map inputs.

3. `fix: tighten component detectors`
   - Reduces React false positives by detecting functions that return JSX rather than arbitrary JSX nodes.
   - Narrows Vue Options API and Composition API matching to component context / Vue imports.
   - Adds negative detector fixtures.

4. `fix: throw scanner errors from library API`
   - Replaces `process.exit` in `projectScanner` with typed scanner errors.
   - Moves CLI exit behavior to `bin.js`.
   - Adds missing input/config error tests.

5. `fix: clean up slim scanner behavior`
   - Removes normal-path logging from `componentScanner`.
   - Enables Vue JSX detection in slim scanner.

6. `ci: run tests with frozen installs`
   - Pins the workspace package manager to pnpm 8.15.9.
   - Updates GitHub Actions to current major versions.
   - Adds a core test job before Pages build/deploy.
   - Uses `pnpm install --frozen-lockfile` in CI.

7. `chore: improve package release metadata`
   - Adds npm metadata.
   - Reads CLI version from `package.json`.
   - Adds a `componentlook --version` smoke test.

## Validation

```bash
CI=true npx pnpm@8.15.9 install --frozen-lockfile
CI=true npx pnpm@8.15.9 --filter componentlook test
CI=true npx pnpm@8.15.9 --filter @componentlook/web build
```

Notes:

- The web build passes with existing dependency warnings from Svelte 5 prerelease / third-party Svelte packages.
- The local `pnpm` shim on this machine attempted to prepare pnpm under `~/Library/pnpm` and hit a permission error after adding `packageManager`; validation used `npx pnpm@8.15.9`, matching CI.

Closes #2.
