### PR TITLE
Improve scanner API and reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ console.log(report.reactFunctionFileList);
 console.log(report.vueCompositionFileList);
 ```
 
+Detect a component style directly from source code:
+
+```js
+import { COMPONENT_TYPE, detectComponentType, isComponentType } from "componentlook";
+
+const fileContent = `
+export function ProfileCard() {
+  return <section>Profile</section>;
+}
+`;
+
+const detectedType = detectComponentType(fileContent, { fileName: "ProfileCard.tsx" });
+const isReactFunction = isComponentType(
+  COMPONENT_TYPE.REACT_FUNCTION,
+  fileContent,
+  { fileName: "ProfileCard.tsx" }
+);
+```
+
 For lightweight single-file or pre-compiled use cases, see the `componentlook/slim` export.
 
 ## Local Development

--- a/packages/core/readme.md
+++ b/packages/core/readme.md
@@ -54,6 +54,36 @@ componentlook src/index.tsx
 
 ```
 
+## Programmatic API
+
+Scan a project entry and convert the grouped result:
+
+```js
+import { projectScanner, convertResult } from "componentlook";
+
+const resultMap = await projectScanner(["src/index.tsx"]);
+const report = convertResult(resultMap);
+```
+
+Detect component style directly from a source string:
+
+```js
+import { COMPONENT_TYPE, detectComponentType, isComponentType } from "componentlook";
+
+const fileContent = `
+export function ProfileCard() {
+  return <section>Profile</section>;
+}
+`;
+
+const detectedType = detectComponentType(fileContent, { fileName: "ProfileCard.tsx" });
+const isReactFunction = isComponentType(
+  COMPONENT_TYPE.REACT_FUNCTION,
+  fileContent,
+  { fileName: "ProfileCard.tsx" }
+);
+```
+
 
 
 ## License

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -11,7 +11,6 @@ import { printResult, convertResult } from "./utils/index.js";
 import { getDependencies, readJson } from "./utils/string.js";
 import { existsSync } from "fs";
 import { createHost } from "./typescript/create-host.js";
-import { componentScanner } from './slim.js';
  
 export class ScannerError extends Error {
   /**
@@ -151,4 +150,10 @@ export async function parse(_entry, options) {
   printResult(res);
 }
 
-export { convertResult, componentScanner }
+export {
+  componentScanner,
+  COMPONENT_TYPE,
+  detectComponentType,
+  isComponentType
+} from './slim.js';
+export { convertResult };

--- a/packages/core/src/slim.js
+++ b/packages/core/src/slim.js
@@ -8,6 +8,51 @@ import { isVueOptionAPI } from "./pattern/vue/option.js";
 import { COMPONENT_TYPE } from "./constant/index.js";
 
 /**
+ * @param {string} fileName
+ * @returns {ts.ScriptKind}
+ */
+function getScriptKind(fileName) {
+  if (fileName.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  if (fileName.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (fileName.endsWith(".ts")) return ts.ScriptKind.TS;
+  if (fileName.endsWith(".vue")) return ts.ScriptKind.TSX;
+
+  return ts.ScriptKind.JS;
+}
+
+/**
+ * Detect the first component writing style in a source string.
+ *
+ * @param {string} fileContent
+ * @param {{fileName?: string}} [options]
+ * @returns {string}
+ */
+export function detectComponentType(fileContent, options = {}) {
+  const fileName = options.fileName || "Component.tsx";
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    fileContent,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(fileName)
+  );
+
+  return componentScanner(sourceFile);
+}
+
+/**
+ * Check whether a source string matches a specific component writing style.
+ *
+ * @param {string} componentType
+ * @param {string} fileContent
+ * @param {{fileName?: string}} [options]
+ * @returns {boolean}
+ */
+export function isComponentType(componentType, fileContent, options = {}) {
+  return detectComponentType(fileContent, options) === componentType;
+}
+
+/**
  *
  * @param {ts.SourceFile} sourceFile
  * @returns
@@ -61,3 +106,5 @@ export function componentScanner(sourceFile) {
 
   return componentType;
 }
+
+export { COMPONENT_TYPE };

--- a/packages/core/tests/component-code-api/index.test.js
+++ b/packages/core/tests/component-code-api/index.test.js
@@ -1,0 +1,59 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import {
+  COMPONENT_TYPE,
+  detectComponentType,
+  isComponentType
+} from '../../src/index.js';
+
+const reactFunctionCode = `
+import React from 'react';
+
+export function ProfileCard() {
+  return <section>Profile</section>;
+}
+`;
+
+const vueCompositionCode = `
+import { reactive } from 'vue';
+
+export default {
+  setup() {
+    const state = reactive({ count: 0 });
+    return { state };
+  }
+}
+`;
+
+const plainCode = `
+export function add(a, b) {
+  return a + b;
+}
+`;
+
+test('detects a component type from file content', () => {
+  assert.equal(
+    detectComponentType(reactFunctionCode, { fileName: 'ProfileCard.tsx' }),
+    COMPONENT_TYPE.REACT_FUNCTION
+  );
+});
+
+test('checks whether file content matches the requested component type', () => {
+  assert.is(
+    isComponentType(COMPONENT_TYPE.VUE_COMPOSITION, vueCompositionCode, { fileName: 'ProfileCard.vue' }),
+    true
+  );
+});
+
+test('returns false when file content does not match the requested component type', () => {
+  assert.is(
+    isComponentType(COMPONENT_TYPE.REACT_CLASS, reactFunctionCode, { fileName: 'ProfileCard.tsx' }),
+    false
+  );
+});
+
+test('returns an empty component type for non-component file content', () => {
+  assert.equal(detectComponentType(plainCode, { fileName: 'math.ts' }), '');
+});
+
+test.run();


### PR DESCRIPTION
## Summary
- Fix scanner reliability issues so tests run portably and library errors throw instead of exiting
- Preserve multiple detected component styles per file in project scan output
- Add source-string APIs for issue #1: `detectComponentType(fileContent, options)`, `isComponentType(componentType, fileContent, options)`, and exported `COMPONENT_TYPE`
- Document the programmatic API examples

Closes #1

## Tests
- `npm test` from `packages/core` (26 passed)

Note: `pnpm --filter componentlook test` is blocked on this machine by pnpm tools directory permissions: `EACCES mkdir /Users/merchant/Library/pnpm/.tools/pnpm/8.15.9_tmp...`.